### PR TITLE
correct IRI for Mississipi_River

### DIFF
--- a/json-best-practice/clause_7-from_json_to_jsonld.adoc
+++ b/json-best-practice/clause_7-from_json_to_jsonld.adoc
@@ -205,7 +205,7 @@ A special kind of data type is "@id". This indicates that a property points to a
         "owscommon":"http://www.opengis.net/def/ows-common/",
         "resource": "http://dbpedia.org/resource/",
         "dbpedia": "http://dbpedia.org/ontology/",
-        "wiki": "http://en.wikipedia.org/wiki/Mississippi_River",
+        "wiki": "http://en.wikipedia.org/wiki/",
 		"describedBy": {
 			"@id": "http://www.iana.org/assignments/relation/describedby",
 			"@type": "@id"

--- a/json-best-practice/clause_7-from_json_to_jsonld.adoc
+++ b/json-best-practice/clause_7-from_json_to_jsonld.adoc
@@ -18,7 +18,7 @@ First of all, JSON-LD defines two specific properties for each object: @id and @
 [source,json]
 ----
 {
-    "@id": "http://dbpedia.org/page/Mississippi_River",
+    "@id": "http://dbpedia.org/resource/Mississippi_River",
     "@type": "http://dbpedia.org/ontology/River"
 }
 ----
@@ -28,7 +28,7 @@ Within the context of RDF, a triple is a construct built from a subject, predica
 .Conversion to the minimum example of a river object to RDF triples
 [source,turtle]
 ----
-<http://dbpedia.org/page/Mississippi_River> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://dbpedia.org/ontology/River> .
+<http://dbpedia.org/resource/Mississippi_River> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://dbpedia.org/ontology/River> .
 ----
 
 [NOTE]
@@ -51,7 +51,7 @@ In this example we are adding a _name_ to a river resulting on a second triple a
 ----
 {
     "@context": "http://schema.org/",
-    "@id": "http://dbpedia.org/page/Mississippi_River",
+    "@id": "http://dbpedia.org/resource/Mississippi_River",
     "@type": "http://dbpedia.org/ontology/River",
     "name": "Mississippi river"
 }
@@ -60,8 +60,8 @@ In this example we are adding a _name_ to a river resulting on a second triple a
 .Conversion to a named river object encoded as RDF triples
 [source,turtle]
 ----
-<http://dbpedia.org/page/Mississippi_River> <http://schema.org/name> "Mississippi river" .
-<http://dbpedia.org/page/Mississippi_River> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://dbpedia.org/ontology/River> .
+<http://dbpedia.org/resource/Mississippi_River> <http://schema.org/name> "Mississippi river" .
+<http://dbpedia.org/resource/Mississippi_River> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://dbpedia.org/ontology/River> .
 ----
 
 As a second alternative, when the appropriate vocabulary in the JSON-LD format is not available, we can define the needed term on-the-fly as embedded content in the @context section of the JSON instance.
@@ -73,7 +73,7 @@ As a second alternative, when the appropriate vocabulary in the JSON-LD format i
     "@context": {
         "name": "http://www.opengis.net/def/ows-common/name"
     },
-    "@id": "http://dbpedia.org/page/Mississippi_River",
+    "@id": "http://dbpedia.org/resource/Mississippi_River",
     "@type": "http://dbpedia.org/ontology/River",
     "name": "Mississippi river"
 }
@@ -88,7 +88,7 @@ It is also possible to combine two vocabularies, one pre-existing and another em
     "@context": ["http://schema.org/", {
         "bridges": "http://www.opengis.net/def/ows-common/river/bridge"
     }],
-    "@id": "http://dbpedia.org/page/Mississippi_River",
+    "@id": "http://dbpedia.org/resource/Mississippi_River",
     "@type": "http://dbpedia.org/ontology/River",
     "name": "Mississippi river",
     "bridges": ["Eads Bridge", "Chain of Rocks Bridge"]
@@ -98,10 +98,10 @@ It is also possible to combine two vocabularies, one pre-existing and another em
 .Conversion to a named river object encoded as RDF triples
 [source,turtle]
 ----
-<http://dbpedia.org/page/Mississippi_River> <http://schema.org/name> "Mississippi river" .
-<http://dbpedia.org/page/Mississippi_River> <http://www.opengis.net/def/ows-common/river/bridge> "Chain of Rocks Bridge" .
-<http://dbpedia.org/page/Mississippi_River> <http://www.opengis.net/def/ows-common/river/bridge> "Eads Bridge" .
-<http://dbpedia.org/page/Mississippi_River> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://dbpedia.org/ontology/River> .
+<http://dbpedia.org/resource/Mississippi_River> <http://schema.org/name> "Mississippi river" .
+<http://dbpedia.org/resource/Mississippi_River> <http://www.opengis.net/def/ows-common/river/bridge> "Chain of Rocks Bridge" .
+<http://dbpedia.org/resource/Mississippi_River> <http://www.opengis.net/def/ows-common/river/bridge> "Eads Bridge" .
+<http://dbpedia.org/resource/Mississippi_River> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://dbpedia.org/ontology/River> .
 ----
 
 === Using namespaces in JSON-LD
@@ -114,11 +114,11 @@ Now we can refine the example and provide a more elegant encoding introducing th
 {
     "@context": ["http://schema.org/", {
         "owscommon":"http://www.opengis.net/def/ows-common/",
-        "page": "http://dbpedia.org/page/",
+        "resource": "http://dbpedia.org/resource/",
         "dbpedia": "http://dbpedia.org/ontology/",
         "bridges": "owscommon:river/bridge"
     }],
-    "@id": "page:Mississippi_River",
+    "@id": "resource:Mississippi_River",
     "@type": "dbpedia:River",
     "name": "Mississippi river",
     "bridges": ["Eads Bridge", "Chain of Rocks Bridge"]
@@ -135,15 +135,15 @@ By default, JSON-LD considers properties as strings. JSON-LD also permits defini
 {
     "@context": ["http://schema.org/", {
         "owscommon":"http://www.opengis.net/def/ows-common/",
-        "page": "http://dbpedia.org/page/",
+        "resource": "http://dbpedia.org/resource/",
         "dbpedia": "http://dbpedia.org/ontology/",
         "bridges": "owscommon:river/bridge",
-		"length": {
-			"@id": "http://schema.org/distance",
-			"@type": "xsd:float"
-    	}
+        "length": {
+            "@id": "http://schema.org/distance",
+            "@type": "xsd:float"
+        }
     }],
-    "@id": "page:Mississippi_River",
+    "@id": "resource:Mississippi_River",
     "@type": "dbpedia:River",
     "name": "Mississippi river",
     "bridges": ["Eads Bridge", "Chain of Rocks Bridge"],
@@ -154,7 +154,7 @@ By default, JSON-LD considers properties as strings. JSON-LD also permits defini
 .Conversion of the length of a river object to RDF triples
 [source,turtle]
 ----
-<http://dbpedia.org/page/Mississippi_River> <http://schema.org/distance> "3734"^^<http://www.w3.org/2001/XMLSchema#float> .
+<http://dbpedia.org/resource/Mississippi_River> <http://schema.org/distance> "3734"^^<http://www.w3.org/2001/XMLSchema#float> .
 [...]
 ----
 
@@ -168,14 +168,14 @@ An interesting aspect of JSON-LD is that it overwrites the behavior of JSON arra
 {
     "@context": ["http://schema.org/", {
         "owscommon":"http://www.opengis.net/def/ows-common/",
-        "page": "http://dbpedia.org/page/",
+        "resource": "http://dbpedia.org/resource/",
         "dbpedia": "http://dbpedia.org/ontology/",
         "bridges": {
           	"@id": "owscommon:river/bridge",
             "@container": "@list"
         }
    }],
-    "@id": "page:Mississippi_River",
+    "@id": "resource:Mississippi_River",
     "@type": "dbpedia:River",
     "name": "Mississippi river",
     "bridges": ["Eads Bridge", "Chain of Rocks Bridge"]
@@ -185,9 +185,9 @@ An interesting aspect of JSON-LD is that it overwrites the behavior of JSON arra
 .Transformation, to RDF triples, of a list of bridges where order is important
 [source,json]
 ----
-<http://dbpedia.org/page/Mississippi_River> <http://schema.org/name> "Mississippi river" .
-<http://dbpedia.org/page/Mississippi_River> <http://www.opengis.net/def/ows-common/river/bridge> _:b0 .
-<http://dbpedia.org/page/Mississippi_River> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://dbpedia.org/ontology/River> .
+<http://dbpedia.org/resource/Mississippi_River> <http://schema.org/name> "Mississippi river" .
+<http://dbpedia.org/resource/Mississippi_River> <http://www.opengis.net/def/ows-common/river/bridge> _:b0 .
+<http://dbpedia.org/resource/Mississippi_River> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://dbpedia.org/ontology/River> .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "Eads Bridge" .
 _:b0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#rest> _:b1 .
 _:b1 <http://www.w3.org/1999/02/22-rdf-syntax-ns#first> "Chain of Rocks Bridge" .
@@ -203,7 +203,7 @@ A special kind of data type is "@id". This indicates that a property points to a
 {
     "@context": ["http://schema.org/", {
         "owscommon":"http://www.opengis.net/def/ows-common/",
-        "page": "http://dbpedia.org/page/",
+        "resource": "http://dbpedia.org/resource/",
         "dbpedia": "http://dbpedia.org/ontology/",
         "wiki": "http://en.wikipedia.org/wiki/Mississippi_River",
 		"describedBy": {
@@ -211,7 +211,7 @@ A special kind of data type is "@id". This indicates that a property points to a
 			"@type": "@id"
 		}
     }],
-    "@id": "page:Mississippi_River",
+    "@id": "resource:Mississippi_River",
     "@type": "dbpedia:River",
     "name": "Mississippi river",
     "describedBy":  "wiki:Mississippi_River"
@@ -221,7 +221,7 @@ A special kind of data type is "@id". This indicates that a property points to a
 .Conversion to a river object related to another object encoded as RDF triples
 [source,turtle]
 ----
-<http://dbpedia.org/page/Mississippi_River> <http://schema.org/name> "Mississippi river" .
-<http://dbpedia.org/page/Mississippi_River> <http://www.iana.org/assignments/relation/describedby> <http://en.wikipedia.org/wiki/Mississippi_RiverMississippi_River> .
-<http://dbpedia.org/page/Mississippi_River> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://dbpedia.org/ontology/River> .
+<http://dbpedia.org/resource/Mississippi_River> <http://schema.org/name> "Mississippi river" .
+<http://dbpedia.org/resource/Mississippi_River> <http://www.iana.org/assignments/relation/describedby> <http://en.wikipedia.org/wiki/Mississippi_RiverMississippi_River> .
+<http://dbpedia.org/resource/Mississippi_River> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://dbpedia.org/ontology/River> .
 ----


### PR DESCRIPTION
Technically the IRI <http://dbpedia.org/page/Mississippi_River> does not identify the river, it identifies *the web page describing* the river. The correct IRI for the river is <http://dbpedia.org/resource/Mississippi_River> (and yes, it redirects to the 'page' URL, because obviously, you can not retrieve the river itself over the internet...).